### PR TITLE
Set `WP_TESTS_DOMAIN` from `$_SERVER['HTTP_HOST']`.

### DIFF
--- a/modules/tester/templates/wp-tests-config.php.erb
+++ b/modules/tester/templates/wp-tests-config.php.erb
@@ -68,8 +68,8 @@ if ( empty( $table_prefix ) )
 // =====================================
 defined( 'WP_DEBUG' ) or define( 'WP_DEBUG', true );
 
-define( 'WP_TESTS_DOMAIN', 'example.org' );
-define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_DOMAIN', $_SERVER['HTTP_HOST'] );
+define( 'WP_TESTS_EMAIL', 'admin@' . $_SERVER['HTTP_HOST'] );
 define( 'WP_TESTS_TITLE', 'Test Blog' );
 
 define( 'WP_PHP_BINARY', 'php' );


### PR DESCRIPTION
`WP_TESTS_DOMAIN` is used by some test suites as a way of getting the test site's domain.
The constant should be set to the host that Chassis is running on, to avoid differences in URLs generated by WordPress vs. URLs manually constructed in a test.