### PR TITLE
Custom config file & database

### DIFF
--- a/modules/tester/manifests/init.pp
+++ b/modules/tester/manifests/init.pp
@@ -1,6 +1,6 @@
 class tester (
 	$install_path = "/usr/local/src/phpunit",
-	$tester_config = sz_load_config()
+	$tester_config = sz_load_config(),
 ) {
 	# Create the install path
 	file { $install_path:
@@ -32,5 +32,14 @@ class tester (
 		ensure  => link,
 		target  => "$install_path/phpunit.phar",
 		require => File[ "$install_path/phpunit.phar" ],
+	}
+
+	if ( $tester_config[tester_db] ) {
+		mysql::db { $tester_config[tester_db][name]:
+			user     => $tester_config[tester_db][user],
+			password => $tester_config[tester_db][password],
+			host     => localhost,
+			grant    => ['all'],
+		}
 	}
 }

--- a/modules/tester/manifests/init.pp
+++ b/modules/tester/manifests/init.pp
@@ -1,6 +1,6 @@
 class tester (
 	$install_path = "/usr/local/src/phpunit",
-	$tester_config = sz_load_config(),
+	$tester_config = sz_load_config()
 ) {
 	# Create the install path
 	file { $install_path:

--- a/modules/tester/templates/wp-tests-config.php.erb
+++ b/modules/tester/templates/wp-tests-config.php.erb
@@ -3,7 +3,11 @@
 // Load database info and local development parameters
 // ===================================================
 $chassisdir = '/vagrant';
-if ( file_exists( $chassisdir . '/local-config-db.php' ) ) {
+
+if ( file_exists( $chassisdir . '/local-config-tester.php' ) ) {
+	define( 'WP_LOCAL_DEV', true );
+	include( $chassisdir . '/local-config-tester.php' );
+} elseif ( file_exists( $chassisdir . '/local-config-db.php' ) ) {
 	define( 'WP_LOCAL_DEV', true );
 	include( $chassisdir . '/local-config-db.php' );
 }


### PR DESCRIPTION
I would like to be able to specify a custom `wp-config` file for my tests. 

The reason I want to do this is to run my tests against a different install of WP. EG run them against the WP develop bundled with chassis tester extension) and load only the theme/plugin I wish to test. However, because it loads the standard chassis `wp-config-db.php`, ABSPATH gets defined here.

Additionally, I'd like to be able to have the tests use a different database. I ran into problems just relying on the prefix when my tests caused fatal errors. If this happens, the `test_` DB tables aren't cleaned up. When I then try to re-provision the box, I get an error insisting I specify a prefix in my config.yml. When the tests run OK, they are cleaned up OK and all is fine... so maybe this isn't too big a deal. 

I'm just playing around a bit here. Maybe there are better ways to achieve my goals. I'm all ears :)