### PR TITLE
Fix PHPunit version

### DIFF
--- a/modules/tester/manifests/init.pp
+++ b/modules/tester/manifests/init.pp
@@ -8,9 +8,9 @@ class tester (
 	}
 
 	if $tester_config[php] < 5.6 {
-		$phpunit_repo_url = "https://phar.phpunit.de/phpunit-5.7.phar"
-	} else {
 		$phpunit_repo_url = "https://phar.phpunit.de/phpunit-4.8.phar"
+	} else {
+		$phpunit_repo_url = "https://phar.phpunit.de/phpunit-5.7.phar"
 	}
 
 	# Download phpunit


### PR DESCRIPTION
I think its fine to be using PHPunit 5.7 as standard, and I was wondering why it installed 4.8... Looks like the logic is the wrong way around here! I guess nobody running tests is doing so on PHP 5.5 and below 😄 