### PR TITLE
Use PHPUnit 6.x for PHP 7.x versions

### DIFF
--- a/modules/tester/manifests/init.pp
+++ b/modules/tester/manifests/init.pp
@@ -20,7 +20,7 @@ class tester (
 		if ( $config[php] < 5.6 ) {
 			$phpunit_repo_url = 'https://phar.phpunit.de/phpunit-4.8.phar'
 		} else {
-			$phpunit_repo_url = 'https://phar.phpunit.de/phpunit-5.7.phar'
+			$phpunit_repo_url = 'https://phar.phpunit.de/phpunit-6.5.phar'
 		}
 
 		# Download phpunit


### PR DESCRIPTION
This brings the Chassis Tester extension inline with WordPress Core, see [r41294](https://core.trac.wordpress.org/changeset/41294)