### PR TITLE
Add support for generating local-config-tester.php file

### DIFF
--- a/modules/tester/manifests/config.pp
+++ b/modules/tester/manifests/config.pp
@@ -1,35 +1,55 @@
 # Tester extension for Chassis
 class tester::config (
-	$test_database = undef,
-	$test_database_user = undef,
-	$test_database_password = undef,
-	$test_database_host = undef,
-	$test_database_prefix = 'test_',
+  $test_config = {},
+  $ensure = present,
 ) {
-  if ( ! empty( $::config[disabled_extensions] ) and 'chassis/tester' in $::config[disabled_extensions] ) {
-    $file = absent
-  } else {
-    $file = present
+  # If test DB configuration was provided, pull those values out.
+  $test_database = $test_config[name] ? {
+    /.*/ => $test_config[name],
+    default => undef,
+  }
+  $test_database_user = $test_config[user] ? {
+    /.*/ => $test_config[user],
+    default => undef,
+  }
+  $test_database_password = $test_config[password] ? {
+    /.*/ => $test_config[password],
+    default => 'password',
+  }
+  $test_database_host = $test_config[host] ? {
+    /.*/ => $test_config[host],
+    default => 'localhost',
+  }
+  $test_database_prefix = $test_config[prefix] ? {
+    /.*/ => $test_config[prefix],
+    default => 'test_',
   }
 
   file { '/vagrant/extensions/tester/wpdevel/wp-tests-config.php':
-    ensure  => $file,
+    ensure  => $ensure,
     content => template('tester/wp-tests-config.php.erb')
   }
 
   file { '/etc/profile.d/tester-env.sh':
-    ensure  => $file,
+    ensure  => $ensure,
     content => template('tester/tester-env.sh.erb')
   }
 
-  if ( $file == absent or $test_database ) {
-    file { '/vagrant/local-config-tester.php':
-      ensure  => $file,
-      content => template('tester/local-config-tester.php.erb')
-    }
+  # Determine whether a DB configuration file should exist.
+  if ( absent == $ensure ) {
+    $db_config_file = absent
+  } elsif ( empty( $test_database ) and empty( $test_database_user ) ) {
+    $db_config_file = absent
+  } else {
+    $db_config_file = present
   }
 
-  if ( present == $file ) {
+  file { '/vagrant/local-config-tester.php':
+    ensure  => $db_config_file,
+    content => template('tester/local-config-tester.php.erb')
+  }
+
+  if ( present == $ensure ) {
     exec { 'load_tester_envs':
       path      => '/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin',
       command   => "bash -c 'source /etc/profile.d/tester-env.sh'",

--- a/modules/tester/manifests/config.pp
+++ b/modules/tester/manifests/config.pp
@@ -1,5 +1,11 @@
 # Tester extension for Chassis
-class tester::config {
+class tester::config (
+	$test_database = undef,
+	$test_database_user = undef,
+	$test_database_password = undef,
+	$test_database_host = undef,
+	$test_database_prefix = 'test_',
+) {
   if ( ! empty( $::config[disabled_extensions] ) and 'chassis/tester' in $::config[disabled_extensions] ) {
     $file = absent
   } else {
@@ -16,9 +22,18 @@ class tester::config {
     content => template('tester/tester-env.sh.erb')
   }
 
-  exec { 'load_tester_envs':
-    path      => '/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin',
-    command   => "bash -c 'source /etc/profile.d/tester-env.sh'",
-    subscribe => File['/etc/profile.d/tester-env.sh']
+  if ( $file == absent or $test_database ) {
+    file { '/vagrant/local-config-tester.php':
+      ensure  => $file,
+      content => template('tester/local-config-tester.php.erb')
+    }
+  }
+
+  if ( present == $file ) {
+    exec { 'load_tester_envs':
+      path      => '/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin',
+      command   => "bash -c 'source /etc/profile.d/tester-env.sh'",
+      subscribe => File['/etc/profile.d/tester-env.sh']
+    }
   }
 }

--- a/modules/tester/manifests/init.pp
+++ b/modules/tester/manifests/init.pp
@@ -28,11 +28,9 @@ class tester (
 		}
 	}
 
-	# Invoke even if tester is disabled in order to clean up templated files.
+	# Invoke even if tester is disabled, in order to clean up templated files.
 	class { 'tester::config':
-		test_database => $config[tester_db][name],
-		test_database_user => $config[tester_db][user],
-		test_database_password => $config[tester_db][password],
-		test_database_host => $config[tester_db][host],
+		test_config => $config[tester_db],
+		ensure      => $tester,
 	}
 }

--- a/modules/tester/manifests/init.pp
+++ b/modules/tester/manifests/init.pp
@@ -20,13 +20,19 @@ class tester (
 				grant    => ['all']
 			}
 		}
-
-		class { 'tester::config': }
 	} else {
 		exec { 'unset env variables':
 			command  => 'unset WP_DEVELOP_DIR; unset WP_TESTS_DIR;',
 			path     => '/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin',
 			provider => 'shell'
 		}
+	}
+
+	# Invoke even if tester is disabled in order to clean up templated files.
+	class { 'tester::config':
+		test_database => $config[tester_db][name],
+		test_database_user => $config[tester_db][user],
+		test_database_password => $config[tester_db][password],
+		test_database_host => $config[tester_db][host],
 	}
 }

--- a/modules/tester/templates/local-config-tester.php.erb
+++ b/modules/tester/templates/local-config-tester.php.erb
@@ -1,0 +1,15 @@
+<?php
+
+// This is generated automatically by chassis/tester. Edit at your own risk.
+<% if @test_database -%>
+define( 'DB_NAME',     '<%= @test_database %>' );
+<% end -%>
+<% if @test_database_user -%>
+define( 'DB_USER',     '<%= @test_database_user %>' );
+<% end -%>
+<% if @test_database_password -%>
+define( 'DB_PASSWORD', '<%= @test_database_password %>' );
+<% end -%>
+<% if @test_database_host -%>
+define( 'DB_HOST',     '<%= @test_database_host %>' );
+<% end -%>

--- a/modules/tester/templates/wp-tests-config.php.erb
+++ b/modules/tester/templates/wp-tests-config.php.erb
@@ -63,7 +63,7 @@ define( 'DB_COLLATE', '' );
 // Table prefix
 // Change this if you have multiple installs in the same database
 // ==============================================================
-$table_prefix = 'test_';
+$table_prefix = '<%= @test_database_prefix %>';
 
 if ( defined( 'MULTISITE' ) && ! defined( 'WP_TESTS_MULTISITE' ) ) {
 	define( 'WP_TESTS_MULTISITE', (bool) MULTISITE );


### PR DESCRIPTION
We provide a mechanism to create a database with a particular username and password as part of the provisioning process, but no part of this extension appears to expose information about that database to the PHPUnit configuration files.

This PR modifies the config-provisioning class to generate a templated `local-config-tester.php` file in the Chassis root, which will be populated with the values specified within the test_tb config key (if present). So long as the extension is not disabled and a custom database (or DB user) has been specified, this file will be generated and loaded by the test bootstrap.